### PR TITLE
Fix/android

### DIFF
--- a/docs/docs/device-farm/device/settings.mdx
+++ b/docs/docs/device-farm/device/settings.mdx
@@ -52,7 +52,7 @@ When connecting multiple devices to a single host, use a powered USB hub if poss
 ### Configuration
 
 - Please refer to the [Create and manage virtual devices](https://developer.android.com/studio/run/managing-avds) document to create a virtual device.
-- In the Select a system image step, set API Level 33 or lower.
+- In the Select a system image step, set API Level 26 or higher.
 - In the Create a hardware profile step, set the RAM to 4GB or more.
 
 </TabItem>

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/device-farm/device/settings.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/device-farm/device/settings.mdx
@@ -51,7 +51,7 @@ import Admonition from '@theme/Admonition';
 ### 설정
 
 - [Create and manage virtual devices](https://developer.android.com/studio/run/managing-avds) 문서를 참고하여 가상 디바이스를 생성해주세요.
-- Select a system image 단계에서 API Level 33 이하로 설정해주세요.
+- Select a system image 단계에서 API Level 26 이상으로 설정해주세요.
 - Create a hardware profile 단계에서 RAM을 4GB 이상으로 설정해주세요.
 
 </TabItem>

--- a/nm-space/projects/dost/src/pages/OpenSourceSoftwareNotice.tsx
+++ b/nm-space/projects/dost/src/pages/OpenSourceSoftwareNotice.tsx
@@ -6,8 +6,8 @@ import { ipc } from '../utils/window';
 interface OpenSourceSoftware {
   name: string;
   link: string;
-  version: string;
-  codeLink: string;
+  version?: string;
+  codeLink?: string;
   licenseName: string;
   licenseLink: string;
 }
@@ -32,21 +32,25 @@ function OpenSourceSoftwareNotice() {
               </Button>
 
               <UnorderedList>
-                <ListItem>
-                  <Text>version: {software.version}</Text>
-                </ListItem>
-                <ListItem>
-                  code:&nbsp;
-                  <Button
-                    variant="link"
-                    onClick={() => {
-                      ipc.settingsClient.openExternal(software.codeLink);
-                    }}
-                    width="max-content"
-                  >
-                    {software.codeLink}
-                  </Button>
-                </ListItem>
+                {software.version && (
+                  <ListItem>
+                    <Text>version: {software.version}</Text>
+                  </ListItem>
+                )}
+                {software.codeLink && (
+                  <ListItem>
+                    code:&nbsp;
+                    <Button
+                      variant="link"
+                      onClick={() => {
+                        ipc.settingsClient.openExternal(software.codeLink!);
+                      }}
+                      width="max-content"
+                    >
+                      {software.codeLink}
+                    </Button>
+                  </ListItem>
+                )}
                 <ListItem>
                   license: {software.licenseName}&nbsp;
                   <Button
@@ -72,20 +76,12 @@ export default OpenSourceSoftwareNotice;
 
 const softwares: OpenSourceSoftware[] = [
   {
-    name: 'git',
-    link: 'https://git-scm.com/',
-    version: '2.39.3',
-    codeLink: 'https://github.com/git/git/tree/v2.39.3',
-    licenseName: 'GPL v2',
-    licenseLink: 'https://github.com/git/git/blob/v2.39.3/COPYING',
-  },
-  {
-    name: 'node',
-    link: 'https://nodejs.org',
-    version: '16.20.0',
-    codeLink: 'https://github.com/nodejs/node/tree/v16.20.0',
-    licenseName: 'MIT License',
-    licenseLink: 'https://github.com/nodejs/node/blob/v16.20.0/LICENSE',
+    name: 'adb-join-wifi',
+    link: 'https://github.com/steinwurf/adb-join-wifi',
+    version: '1.0.1',
+    codeLink: 'https://github.com/steinwurf/adb-join-wifi/tree/1.0.1',
+    licenseName: 'BSD 3-Clause',
+    licenseLink: 'https://github.com/steinwurf/adb-join-wifi/blob/1.0.1/LICENSE.rst',
   },
   {
     name: 'appium',
@@ -96,14 +92,6 @@ const softwares: OpenSourceSoftware[] = [
     licenseLink: 'https://github.com/appium/appium/blob/master/LICENSE',
   },
   {
-    name: 'mobiledevice',
-    link: 'https://github.com/imkira/mobiledevice',
-    version: '2.0.0',
-    codeLink: 'https://github.com/imkira/mobiledevice/releases/tag/v2.0.0',
-    licenseName: 'MIT License',
-    licenseLink: 'https://github.com/imkira/mobiledevice/blob/v2.0.0/LICENSE',
-  },
-  {
     name: 'ffmpeg',
     link: 'https://ffmpeg.org/',
     version: '6.0-tessus',
@@ -112,12 +100,12 @@ const softwares: OpenSourceSoftware[] = [
     licenseLink: 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/refs/heads/release/6.0:/LICENSE.md',
   },
   {
-    name: 'zlib',
-    link: 'https://zlib.net/',
-    version: '1.2.13',
-    codeLink: 'https://www.zlib.net/zlib-1.2.13.tar.gz',
-    licenseName: 'zlib license',
-    licenseLink: 'https://zlib.net/zlib_license.html',
+    name: 'git',
+    link: 'https://git-scm.com/',
+    version: '2.39.3',
+    codeLink: 'https://github.com/git/git/tree/v2.39.3',
+    licenseName: 'GPL v2',
+    licenseLink: 'https://github.com/git/git/blob/v2.39.3/COPYING',
   },
   {
     name: 'libimobiledevice',
@@ -128,11 +116,33 @@ const softwares: OpenSourceSoftware[] = [
     licenseLink: 'https://github.com/libimobiledevice/libimobiledevice/blob/1.0.6/COPYING',
   },
   {
-    name: 'adb-join-wifi',
-    link: 'https://github.com/steinwurf/adb-join-wifi',
-    version: '1.0.1',
-    codeLink: 'https://github.com/steinwurf/adb-join-wifi/tree/1.0.1',
-    licenseName: 'BSD 3-Clause',
-    licenseLink: 'https://github.com/steinwurf/adb-join-wifi/blob/1.0.1/LICENSE.rst',
+    name: 'mobiledevice',
+    link: 'https://github.com/imkira/mobiledevice',
+    version: '2.0.0',
+    codeLink: 'https://github.com/imkira/mobiledevice/releases/tag/v2.0.0',
+    licenseName: 'MIT License',
+    licenseLink: 'https://github.com/imkira/mobiledevice/blob/v2.0.0/LICENSE',
+  },
+  {
+    name: 'node',
+    link: 'https://nodejs.org',
+    version: '16.20.0',
+    codeLink: 'https://github.com/nodejs/node/tree/v16.20.0',
+    licenseName: 'MIT License',
+    licenseLink: 'https://github.com/nodejs/node/blob/v16.20.0/LICENSE',
+  },
+  {
+    name: 'zlib',
+    link: 'https://zlib.net/',
+    version: '1.2.13',
+    codeLink: 'https://www.zlib.net/zlib-1.2.13.tar.gz',
+    licenseName: 'zlib license',
+    licenseLink: 'https://zlib.net/zlib_license.html',
+  },
+  {
+    name: 'scrcpy',
+    link: 'https://github.com/Genymobile/scrcpy',
+    licenseName: 'Apache License 2.0',
+    licenseLink: 'https://github.com/Genymobile/scrcpy/blob/master/LICENSE',
   },
 ];

--- a/packages/typescript-private/device-server/docs/android-emulator.md
+++ b/packages/typescript-private/device-server/docs/android-emulator.md
@@ -1,0 +1,8 @@
+## Android Emulator
+
+The Android Emulator is a virtual mobile device that runs on your computer.
+
+### Notes
+
+- the serial that shown at the result of `adb devices` is not the unique identifier of the emulator. just reflecting running emulator's index
+- ro.serialno is same on all emulators in the same machine

--- a/packages/typescript-private/device-server/src/internal/channel/android-channel.ts
+++ b/packages/typescript-private/device-server/src/internal/channel/android-channel.ts
@@ -440,7 +440,7 @@ async function generateSerialUnique(systemInfo: DeviceSystemInfo): Promise<strin
     return systemInfo.system.serial; // should use ro.serialno value of "adb getprop". because when connect device with wifi, serial from "adb devices" changes.
   }
   const uuid = await systeminformation.uuid();
-  const serialUnique = `${uuid.os}-${systemInfo.system.serial}`;
+  const serialUnique = `${uuid.os}-${systemInfo.system.model}`;
 
   return serialUnique;
 }

--- a/packages/typescript-private/device-server/src/internal/channel/android-channel.ts
+++ b/packages/typescript-private/device-server/src/internal/channel/android-channel.ts
@@ -436,6 +436,20 @@ export class AndroidChannel implements DeviceChannel {
 }
 
 async function generateSerialUnique(systemInfo: DeviceSystemInfo): Promise<string> {
+  /*
+   * @note
+   * ## adb devices
+   * real-device-a with usb    R3CN203JWKV
+   * real-device-a with wifi   adb-R3CN203JWKV-KYVaup._adb-tls-connect._tcp.
+   * emulator-a                emulator-5554
+   * emulator-b                emulator-5556
+   *
+   * ## adb shell getprop | grep ro.serialno
+   * real-device-a with usb    R3CN203JWKV
+   * real-device-a with wifi   R3CN203JWKV
+   * emulator-a                EMULATOR32X1X15X0
+   * emulator-b                EMULATOR32X1X15X0
+   */
   if (!systemInfo.isVirtual) {
     return systemInfo.system.serial; // should use ro.serialno value of "adb getprop". because when connect device with wifi, serial from "adb devices" changes.
   }

--- a/packages/typescript-private/device-server/src/internal/services/system-info/android-system-info-service.ts
+++ b/packages/typescript-private/device-server/src/internal/services/system-info/android-system-info-service.ts
@@ -29,7 +29,7 @@ export class AndroidSystemInfoService implements SystemInfoService {
         manufacturer: deviceProp.ro_product_manufacturer,
         model: modelName,
         version: '',
-        serial: deviceProp.ro_serialno,
+        serial: isVirtual ? serial : deviceProp.ro_serialno, // ro_serialno is same on emulator
         uuid: '',
         sku: '',
       },

--- a/packages/typescript-private/device-server/src/internal/services/system-info/android-system-info-service.ts
+++ b/packages/typescript-private/device-server/src/internal/services/system-info/android-system-info-service.ts
@@ -29,7 +29,7 @@ export class AndroidSystemInfoService implements SystemInfoService {
         manufacturer: deviceProp.ro_product_manufacturer,
         model: modelName,
         version: '',
-        serial: isVirtual ? serial : deviceProp.ro_serialno, // ro_serialno is same on emulator
+        serial: isVirtual ? serial : deviceProp.ro_serialno, // ro_serialno is same on multiple emulator in same host
         uuid: '',
         sku: '',
       },

--- a/packages/typescript-private/device-server/src/internal/services/system-info/android-system-info-service.ts
+++ b/packages/typescript-private/device-server/src/internal/services/system-info/android-system-info-service.ts
@@ -29,7 +29,7 @@ export class AndroidSystemInfoService implements SystemInfoService {
         manufacturer: deviceProp.ro_product_manufacturer,
         model: modelName,
         version: '',
-        serial: isVirtual ? serial : deviceProp.ro_serialno, // ro_serialno is same on multiple emulator in same host
+        serial: deviceProp.ro_serialno,
         uuid: '',
         sku: '',
       },

--- a/projects/android-device-agent/android/app/build.gradle
+++ b/projects/android-device-agent/android/app/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlinx-serialization'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
     defaultConfig {
         applicationId "com.dogu.deviceagent"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 34
         versionCode 12400
         versionName "1.24"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/projects/android-device-agent/android/app/src/main/kotlin/com/dogu/deviceagent/protoapi/ApplyStreamingOptionAPIHandler.kt
+++ b/projects/android-device-agent/android/app/src/main/kotlin/com/dogu/deviceagent/protoapi/ApplyStreamingOptionAPIHandler.kt
@@ -27,9 +27,12 @@ class ApplyStreamingOptionAPIHandler : IDcDaProtoAPIHandler {
             it.write(Json.encodeToString(Options.serializer(), appContext.options))
         }
         if(!befOption.equals(appContext.options)){
+            Logger.v( "ApplyStreamingOptionAPIHandler.handle close before stream")
             appContext.streamChannel?.close(Exception("Streaming option changed"))
+            Logger.v( "ApplyStreamingOptionAPIHandler.handle close before stream done")
         }
 
+        Logger.v( "ApplyStreamingOptionAPIHandler.handle end")
         val applyRet = DcDaTypes.DcDaApplyStreamingOptionReturn.newBuilder().build()
         return DcDaParams.DcDaReturn.newBuilder().setDcDaApplyStreamingOptionReturn(applyRet)
     }

--- a/projects/android-device-agent/android/app/src/main/kotlin/com/dogu/deviceagent/protoapi/ControlAPIHandler.kt
+++ b/projects/android-device-agent/android/app/src/main/kotlin/com/dogu/deviceagent/protoapi/ControlAPIHandler.kt
@@ -36,6 +36,7 @@ class ControlAPIHandler() : ICfGdcDaProtoAPIHandler {
                     "action: ${controlMessage.action},  " +
                     "key: ${controlMessage.key}, " +
                     "keycode: ${controlMessage.keycode}, " +
+                    "meta: ${controlMessage.metaState}, " +
                     "error: $e, " +
                     "stack: ${e.stackTraceToString()}")
             errorResult = com.dogu.protocol.generated.outer.Errors.ErrorResult.newBuilder()

--- a/projects/android-device-agent/android/app/src/main/kotlin/com/dogu/deviceagent/reflect/InputManager.kt
+++ b/projects/android-device-agent/android/app/src/main/kotlin/com/dogu/deviceagent/reflect/InputManager.kt
@@ -1,14 +1,13 @@
 package com.dogu.deviceagent.reflect
 
 
-import android.hardware.input.InputManager
 import android.view.InputEvent
 import com.dogu.deviceagent.Logger
 
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
-class InputManager(private val manager: InputManager) {
+class InputManager(private val manager: Object) {
     @get:Throws(NoSuchMethodException::class)
     private var injectInputEventMethod: Method? = null
         private get() {

--- a/projects/android-device-agent/android/app/src/main/kotlin/com/dogu/deviceagent/router/StreamRouter.kt
+++ b/projects/android-device-agent/android/app/src/main/kotlin/com/dogu/deviceagent/router/StreamRouter.kt
@@ -59,6 +59,7 @@ suspend fun DefaultWebSocketServerSession.routeStream(appContext: AppContext): U
             )
         }
     }
+    Logger.i("DefaultWebSocketServerSession.routeStream $randomId close call")
     streamChannel.close()
 
     Logger.i("DefaultWebSocketServerSession.routeStream $randomId end")

--- a/projects/android-device-agent/android/app/src/main/kotlin/com/dogu/deviceagent/screen/ScreenEncoder.kt
+++ b/projects/android-device-agent/android/app/src/main/kotlin/com/dogu/deviceagent/screen/ScreenEncoder.kt
@@ -196,7 +196,7 @@ class ScreenEncoder(
                 } else {
                     val curTime = System.currentTimeMillis()
                     val elapsedTime = curTime - lastKeyframeShowTime
-                    if (elapsedTime > 5000) {
+                    if (elapsedTime > 3000) {
                         val param = Bundle()
                         param.putInt(MediaCodec.PARAMETER_KEY_REQUEST_SYNC_FRAME, 0)
                         codec.setParameters(param)

--- a/projects/go-device-controller/internal/pkg/device/surface/aos_surface.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/aos_surface.go
@@ -36,8 +36,8 @@ func (s *aosSurface) Reconnect(serial string, screenCaptureOption *streaming.Scr
 	return nil
 }
 
-func (s *aosSurface) Receive(timeout time.Duration) ([]byte, error) {
-	err := s.conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+func (s *aosSurface) Receive() ([]byte, error) {
+	err := s.conn.SetReadDeadline(time.Now().Add(time.Minute * 3)) // include encode intialization time
 	if err != nil {
 		log.Inst.Error("aosSurface.SetReadDeadline error", zap.String("url", *s.agentUrl), zap.Error(err))
 	}

--- a/projects/go-device-controller/internal/pkg/device/surface/aos_surface.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/aos_surface.go
@@ -1,8 +1,6 @@
 package surface
 
 import (
-	"time"
-
 	"go-device-controller/types/protocol/generated/proto/outer/streaming"
 
 	log "go-device-controller/internal/pkg/log"
@@ -37,10 +35,10 @@ func (s *aosSurface) Reconnect(serial string, screenCaptureOption *streaming.Scr
 }
 
 func (s *aosSurface) Receive() ([]byte, error) {
-	err := s.conn.SetReadDeadline(time.Now().Add(time.Minute * 3)) // include encode intialization time
-	if err != nil {
-		log.Inst.Error("aosSurface.SetReadDeadline error", zap.String("url", *s.agentUrl), zap.Error(err))
-	}
+	// err := s.conn.SetReadDeadline(time.Now().Add(time.Minute * 3)) // include encode intialization time
+	// if err != nil {
+	// 	log.Inst.Error("aosSurface.SetReadDeadline error", zap.String("url", *s.agentUrl), zap.Error(err))
+	// }
 	_, buf, err := s.conn.ReadMessage()
 	return buf, err
 }

--- a/projects/go-device-controller/internal/pkg/device/surface/aos_surface.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/aos_surface.go
@@ -25,7 +25,7 @@ func newAosSurface(agentUrl *string) *aosSurface {
 	return &s
 }
 
-func (s *aosSurface) Reconnect(serial string, sleepSec int, screenCaptureOption *streaming.ScreenCaptureOption) error {
+func (s *aosSurface) Reconnect(serial string, screenCaptureOption *streaming.ScreenCaptureOption) error {
 	// reconnect loop
 	var err error
 	s.conn, _, err = websocket.DefaultDialer.Dial(*s.agentUrl, nil)
@@ -36,7 +36,7 @@ func (s *aosSurface) Reconnect(serial string, sleepSec int, screenCaptureOption 
 	return nil
 }
 
-func (s *aosSurface) Receive() ([]byte, error) {
+func (s *aosSurface) Receive(timeout time.Duration) ([]byte, error) {
 	err := s.conn.SetReadDeadline(time.Now().Add(10 * time.Second))
 	if err != nil {
 		log.Inst.Error("aosSurface.SetReadDeadline error", zap.String("url", *s.agentUrl), zap.Error(err))

--- a/projects/go-device-controller/internal/pkg/device/surface/aos_surface.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/aos_surface.go
@@ -35,10 +35,6 @@ func (s *aosSurface) Reconnect(serial string, screenCaptureOption *streaming.Scr
 }
 
 func (s *aosSurface) Receive() ([]byte, error) {
-	// err := s.conn.SetReadDeadline(time.Now().Add(time.Minute * 3)) // include encode intialization time
-	// if err != nil {
-	// 	log.Inst.Error("aosSurface.SetReadDeadline error", zap.String("url", *s.agentUrl), zap.Error(err))
-	// }
 	_, buf, err := s.conn.ReadMessage()
 	return buf, err
 }

--- a/projects/go-device-controller/internal/pkg/device/surface/desktop_libwebrtc_surface.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/desktop_libwebrtc_surface.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"go-device-controller/types/protocol/generated/proto/outer/streaming"
 
@@ -96,11 +97,11 @@ func (s *desktopLibwebrtcSurface) Receive() ([]byte, error) {
 
 	}
 	for {
-		// err := s.conn.SetReadDeadline(time.Now().Add(time.Minute))
-		// if err != nil {
-		// 	log.Inst.Error("desktopLibwebrtcSurface.SetReadDeadline error", zap.Error(err))
-		// }
-		err := s.recvQueue.Push(s.reader)
+		err := s.conn.SetReadDeadline(time.Now().Add(time.Minute))
+		if err != nil {
+			log.Inst.Error("desktopLibwebrtcSurface.SetReadDeadline error", zap.Error(err))
+		}
+		err = s.recvQueue.Push(s.reader)
 		if err != nil {
 			log.Inst.Error("desktopLibwebrtcSurface.Receive push failed", zap.Error(err))
 			return nil, err

--- a/projects/go-device-controller/internal/pkg/device/surface/desktop_libwebrtc_surface.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/desktop_libwebrtc_surface.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
-	"time"
 
 	"go-device-controller/types/protocol/generated/proto/outer/streaming"
 
@@ -97,11 +96,11 @@ func (s *desktopLibwebrtcSurface) Receive() ([]byte, error) {
 
 	}
 	for {
-		err := s.conn.SetReadDeadline(time.Now().Add(time.Minute))
-		if err != nil {
-			log.Inst.Error("desktopLibwebrtcSurface.SetReadDeadline error", zap.Error(err))
-		}
-		err = s.recvQueue.Push(s.reader)
+		// err := s.conn.SetReadDeadline(time.Now().Add(time.Minute))
+		// if err != nil {
+		// 	log.Inst.Error("desktopLibwebrtcSurface.SetReadDeadline error", zap.Error(err))
+		// }
+		err := s.recvQueue.Push(s.reader)
 		if err != nil {
 			log.Inst.Error("desktopLibwebrtcSurface.Receive push failed", zap.Error(err))
 			return nil, err

--- a/projects/go-device-controller/internal/pkg/device/surface/desktop_libwebrtc_surface.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/desktop_libwebrtc_surface.go
@@ -90,14 +90,14 @@ func (s *desktopLibwebrtcSurface) Reconnect(serial string, screenCaptureOption *
 	return nil
 }
 
-func (s *desktopLibwebrtcSurface) Receive(timeout time.Duration) ([]byte, error) {
+func (s *desktopLibwebrtcSurface) Receive() ([]byte, error) {
 	if nil == s.reader {
 		log.Inst.Error("desktopLibwebrtcSurface.Receive reader is null")
 		return nil, errors.Errorf("desktopLibwebrtcSurface.Receive reader is null")
 
 	}
 	for {
-		err := s.conn.SetReadDeadline(time.Now().Add(timeout))
+		err := s.conn.SetReadDeadline(time.Now().Add(time.Minute))
 		if err != nil {
 			log.Inst.Error("desktopLibwebrtcSurface.SetReadDeadline error", zap.Error(err))
 		}

--- a/projects/go-device-controller/internal/pkg/device/surface/desktop_libwebrtc_surface.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/desktop_libwebrtc_surface.go
@@ -38,7 +38,7 @@ func newDesktopLibwebrtcSurface() *desktopLibwebrtcSurface {
 	return &s
 }
 
-func (s *desktopLibwebrtcSurface) Reconnect(serial string, sleepSec int, screenCaptureOption *streaming.ScreenCaptureOption) error {
+func (s *desktopLibwebrtcSurface) Reconnect(serial string, screenCaptureOption *streaming.ScreenCaptureOption) error {
 	var err error
 	var port int
 	listener, port, err, mutex := utils.ListenTCPFreePort()
@@ -90,14 +90,14 @@ func (s *desktopLibwebrtcSurface) Reconnect(serial string, sleepSec int, screenC
 	return nil
 }
 
-func (s *desktopLibwebrtcSurface) Receive() ([]byte, error) {
+func (s *desktopLibwebrtcSurface) Receive(timeout time.Duration) ([]byte, error) {
 	if nil == s.reader {
 		log.Inst.Error("desktopLibwebrtcSurface.Receive reader is null")
 		return nil, errors.Errorf("desktopLibwebrtcSurface.Receive reader is null")
 
 	}
 	for {
-		err := s.conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		err := s.conn.SetReadDeadline(time.Now().Add(timeout))
 		if err != nil {
 			log.Inst.Error("desktopLibwebrtcSurface.SetReadDeadline error", zap.Error(err))
 		}

--- a/projects/go-device-controller/internal/pkg/device/surface/ios_surface.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/ios_surface.go
@@ -67,14 +67,14 @@ func (s *iosSurface) Reconnect(serial string, screenCaptureOption *streaming.Scr
 	return nil
 }
 
-func (s *iosSurface) Receive(timeout time.Duration) ([]byte, error) {
+func (s *iosSurface) Receive() ([]byte, error) {
 	if nil == s.reader {
 		log.Inst.Error("iosSurface.Receive reader is null")
 		return nil, errors.Errorf("iosSurface.Receive reader is null")
 	}
 
 	for {
-		err := s.conn.SetReadDeadline(time.Now().Add(timeout))
+		err := s.conn.SetReadDeadline(time.Now().Add(time.Minute))
 		if err != nil {
 			log.Inst.Error("iosSurface.SetReadDeadline error", zap.String("addr", *s.agentUrl), zap.Error(err))
 		}

--- a/projects/go-device-controller/internal/pkg/device/surface/ios_surface.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/ios_surface.go
@@ -33,9 +33,9 @@ func newiosSurface(agentUrl *string) *iosSurface {
 	return &s
 }
 
-func (s *iosSurface) Reconnect(serial string, sleepSec int, screenCaptureOption *streaming.ScreenCaptureOption) error {
+func (s *iosSurface) Reconnect(serial string, screenCaptureOption *streaming.ScreenCaptureOption) error {
 	var err error
-	log.Inst.Debug("iosSurface.Reconnect", zap.String("serial", serial), zap.String("addr", *s.agentUrl), zap.Int("sleepSec", sleepSec))
+	log.Inst.Debug("iosSurface.Reconnect", zap.String("serial", serial), zap.String("addr", *s.agentUrl))
 	conn, err := net.Dial("tcp", *s.agentUrl)
 	if err != nil {
 		log.Inst.Error("iosSurface.Reconnect", zap.String("serial", serial), zap.String("addr", *s.agentUrl), zap.Error(err))
@@ -67,14 +67,14 @@ func (s *iosSurface) Reconnect(serial string, sleepSec int, screenCaptureOption 
 	return nil
 }
 
-func (s *iosSurface) Receive() ([]byte, error) {
+func (s *iosSurface) Receive(timeout time.Duration) ([]byte, error) {
 	if nil == s.reader {
 		log.Inst.Error("iosSurface.Receive reader is null")
 		return nil, errors.Errorf("iosSurface.Receive reader is null")
 	}
 
 	for {
-		err := s.conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		err := s.conn.SetReadDeadline(time.Now().Add(timeout))
 		if err != nil {
 			log.Inst.Error("iosSurface.SetReadDeadline error", zap.String("addr", *s.agentUrl), zap.Error(err))
 		}
@@ -83,6 +83,7 @@ func (s *iosSurface) Receive() ([]byte, error) {
 			log.Inst.Error("iosSurface.Receive push failed", zap.Error(err))
 			return nil, err
 		}
+
 		if !s.recvQueue.Has() {
 			continue
 		}

--- a/projects/go-device-controller/internal/pkg/device/surface/ios_surface.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/ios_surface.go
@@ -73,10 +73,6 @@ func (s *iosSurface) Receive() ([]byte, error) {
 	}
 
 	for {
-		// err := s.conn.SetReadDeadline(time.Now().Add(time.Minute))
-		// if err != nil {
-		// 	log.Inst.Error("iosSurface.SetReadDeadline error", zap.String("addr", *s.agentUrl), zap.Error(err))
-		// }
 		err := s.recvQueue.Push(s.reader)
 		if err != nil {
 			log.Inst.Error("iosSurface.Receive push failed", zap.Error(err))

--- a/projects/go-device-controller/internal/pkg/device/surface/ios_surface.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/ios_surface.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"time"
 
 	"go-device-controller/types/protocol/generated/proto/outer/streaming"
 
@@ -74,11 +73,11 @@ func (s *iosSurface) Receive() ([]byte, error) {
 	}
 
 	for {
-		err := s.conn.SetReadDeadline(time.Now().Add(time.Minute))
-		if err != nil {
-			log.Inst.Error("iosSurface.SetReadDeadline error", zap.String("addr", *s.agentUrl), zap.Error(err))
-		}
-		err = s.recvQueue.Push(s.reader)
+		// err := s.conn.SetReadDeadline(time.Now().Add(time.Minute))
+		// if err != nil {
+		// 	log.Inst.Error("iosSurface.SetReadDeadline error", zap.String("addr", *s.agentUrl), zap.Error(err))
+		// }
+		err := s.recvQueue.Push(s.reader)
 		if err != nil {
 			log.Inst.Error("iosSurface.Receive push failed", zap.Error(err))
 			return nil, err

--- a/projects/go-device-controller/internal/pkg/device/surface/surface_listener.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/surface_listener.go
@@ -1,6 +1,8 @@
 package surface
 
 type SurfaceListener interface {
+	GetId() int
+	SetId(id int)
 	GetSurfaceListenerType() string
 	OnSurface(timeStamp uint32, Data []byte)
 	OnRTPBytes(timeStamp uint32, Data []byte)

--- a/projects/go-device-controller/internal/pkg/muxer/ffmpeg_muxer.go
+++ b/projects/go-device-controller/internal/pkg/muxer/ffmpeg_muxer.go
@@ -23,6 +23,7 @@ import (
 )
 
 type FFmpegMuxer struct {
+	id        int
 	filePath  string
 	file      *os.File
 	startTime time.Time
@@ -75,6 +76,14 @@ func NewFFmpegMuxer(filePath string, etcParam string, context *types.DcGdcDevice
 	}
 	s.close()
 	return nil, &outer.ErrorResult{Code: outer.Code_CODE_NETWORK_CONNECTION_FAILED, Message: err.Error()}
+}
+
+func (s *FFmpegMuxer) GetId() int {
+	return s.id
+}
+
+func (s *FFmpegMuxer) SetId(id int) {
+	s.id = id
 }
 
 func (s *FFmpegMuxer) FilePath() string {

--- a/projects/go-device-controller/internal/pkg/muxer/muxer.go
+++ b/projects/go-device-controller/internal/pkg/muxer/muxer.go
@@ -8,6 +8,8 @@ import (
 const MuxerType = "Muxer"
 
 type Muxer interface {
+	GetId() int
+	SetId(id int)
 	FilePath() string
 	GetSurfaceListenerType() string
 	OnSurface(timeStamp uint32, Data []byte)

--- a/projects/go-device-controller/internal/pkg/muxer/webm_muxer.go
+++ b/projects/go-device-controller/internal/pkg/muxer/webm_muxer.go
@@ -24,6 +24,7 @@ import (
 )
 
 type WebmMuxer struct {
+	id             int
 	filePath       string
 	videoWriter    webm.BlockWriteCloser
 	videoTimestamp time.Duration
@@ -67,6 +68,14 @@ func NewWebmMuxer(filePath string) (*WebmMuxer, *outer.ErrorResult) {
 	)
 	s.sampleBuilder = samplebuilder.New(30000, &codecs.VP8Packet{}, 90000)
 	return &s, gotypes.Success
+}
+
+func (s *WebmMuxer) GetId() int {
+	return s.id
+}
+
+func (s *WebmMuxer) SetId(id int) {
+	s.id = id
 }
 
 func (s *WebmMuxer) FilePath() string {

--- a/projects/go-device-controller/internal/pkg/relayer/websocket_relayer.go
+++ b/projects/go-device-controller/internal/pkg/relayer/websocket_relayer.go
@@ -56,11 +56,6 @@ func (r *WebsocketRelayer) startRecvLoop() {
 			continue
 		}
 
-		err := r.conn.SetReadDeadline(time.Now().Add(60 * time.Second))
-		if err != nil {
-			log.Inst.Error("WebsocketRelayer.SetReadDeadline error", zap.String("serial", r.serial), zap.Error(err))
-		}
-
 		_, bytes, err := r.conn.ReadMessage()
 		if err != nil {
 			log.Inst.Error("WebsocketRelayer.ReadMessage error", zap.String("serial", r.serial), zap.Error(err))

--- a/projects/go-device-controller/internal/pkg/relayer/websocket_relayer.go
+++ b/projects/go-device-controller/internal/pkg/relayer/websocket_relayer.go
@@ -56,6 +56,11 @@ func (r *WebsocketRelayer) startRecvLoop() {
 			continue
 		}
 
+		err := r.conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+		if err != nil {
+			log.Inst.Error("WebsocketRelayer.SetReadDeadline error", zap.String("serial", r.serial), zap.Error(err))
+		}
+
 		_, bytes, err := r.conn.ReadMessage()
 		if err != nil {
 			log.Inst.Error("WebsocketRelayer.ReadMessage error", zap.String("serial", r.serial), zap.Error(err))
@@ -82,10 +87,6 @@ func reconnect(getUrlFunc func() string, retryCount int, sleepSec int) (*websock
 			time.Sleep(time.Second * time.Duration(sleepSec))
 			count += 1
 			continue
-		}
-		err = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
-		if err != nil {
-			log.Inst.Error("WebsocketRelayer.SetReadDeadline error", zap.String("url", serverUrl), zap.Error(err))
 		}
 		return conn, resp, nil
 	}

--- a/projects/go-device-controller/internal/pkg/streamer/streamer.go
+++ b/projects/go-device-controller/internal/pkg/streamer/streamer.go
@@ -18,6 +18,7 @@ import (
 var seqSeed = 1
 
 type Streamer struct {
+	id                int
 	seq               int
 	mediaPeer         webRTCPeer
 	serial            string
@@ -72,6 +73,14 @@ func newStreamer(serial string, deviceServerPort int32, param *streaming.Streami
 	newWebRTCMediaPeer(&streamer.mediaPeer, &streamer, param.StartStreaming.Platform)
 	streamer.mediaPeer.start(param)
 	return &streamer
+}
+
+func (s *Streamer) GetId() int {
+	return s.id
+}
+
+func (s *Streamer) SetId(id int) {
+	s.id = id
 }
 
 func (s *Streamer) GetSurfaceListenerType() string {

--- a/projects/go-device-controller/internal/pkg/utils/size_prefixed_recv_queue.go
+++ b/projects/go-device-controller/internal/pkg/utils/size_prefixed_recv_queue.go
@@ -29,6 +29,7 @@ func (q *SizePrefixedRecvQueue) Push(reader *bufio.Reader) error {
 	if err != nil {
 		return err
 	}
+
 	q.slice = q.slice[:qEnd+n]
 	return nil
 }

--- a/projects/ios-device-agent/IOSDeviceAgent/DoguScreen/ScreenServer.swift
+++ b/projects/ios-device-agent/IOSDeviceAgent/DoguScreen/ScreenServer.swift
@@ -12,7 +12,7 @@ class ScreenServer {
   var listener: NWListener?
   var aliveConnection: NWConnection?
   var sessionIdSeed: UInt32 = 0
-  var preventGabage : UnknownSession?
+  var preventGabage: UnknownSession?
   var lastSession: Session?
 
   init(port: NWEndpoint.Port) {
@@ -39,11 +39,11 @@ class ScreenServer {
           NSLog("ScreenServer is not initialized")
           return
         }
-        self.lastSession?.close()
         self.preventGabage = UnknownSession(connection: connection) { (connection: NWConnection, type: String, param: Data, error: NWError?) in
           NSLog("ScreenServer on param \(type), \(String(data: param, encoding: .utf8))")
 
           if type == String("screen") {
+            self.lastSession?.close()
             self.sessionIdSeed += 1
             self.lastSession = Session(sessionId: self.sessionIdSeed, connection: connection, param: param)
           } else {


### PR DESCRIPTION
# PR Template

## Checklist

- [ ] E2E finished.
- [x] Local, Self Hosted and Development environment test finished.
- [x] Local, E2E, Self Hosted, Development and Production env variable checked.
- [x] (Backend only) DB migration file creation checked.
- [x] **If this is a API deleted or changed**: Check side effects for API deletion or related code change.

### device-server
- android-channel. change serialUnique to {hostId}-{avd name}

### android-device-agent
- Force keyframe every 3 seconds to handle devices that doesn't work with [MediaFormat.KEY_I_FRAME_INTERVAL](https://developer.android.com/reference/android/media/MediaFormat#KEY_I_FRAME_INTERVAL) https://github.com/dogu-team/dogu/issues/401
- Support android api level 34 https://github.com/dogu-team/dogu/issues/398

### go-device-controller
- Refactor surface.go startRoutine() with select{} expression.
  - Before logic has problem when blocked on receive, the startRoutine() for loop blocked, so reconnecting is delayed.
  - I need non-blocking received. so tried read timeout on aos_surface, ios_surface, ... but when readTimeout occured. the session will be corrupted.
  - So I detach recvLoop with startRecvRoutine goroutine

### ios-device-agent
- fix surface session closing, when heartbeat session requested