### PR TITLE
Fix/trace ios

### DIFF
--- a/nm-space/projects/dost/electron/child/instances/device-server.ts
+++ b/nm-space/projects/dost/electron/child/instances/device-server.ts
@@ -12,6 +12,7 @@ import { FeatureConfigService } from '../../feature-config/feature-config-servic
 import { getLogLevel, logger } from '../../log/logger.instance';
 import { stripAnsi } from '../../log/strip-ansi';
 import { DeviceServerLogsPath, DeviceServerMainScriptPath } from '../../path-map';
+import { checkProjectEqual } from '../../settings/ios-device-agent-project';
 import { Child, ChildLastError, fillChildOptions } from '../types';
 import { closeChild, openChild } from './lifecycle';
 
@@ -32,6 +33,7 @@ export class DeviceServerChild implements Child {
     const DOGU_DEVICE_SERVER_PORT = await appConfigService.get('DOGU_DEVICE_SERVER_PORT');
     const DOGU_DEVICE_PLATFORM_ENABLED = await appConfigService.get('DOGU_DEVICE_PLATFORM_ENABLED');
     const DOGU_DEVICE_IOS_RESTART_ON_INIT = await appConfigService.getOrDefault('DOGU_DEVICE_IOS_RESTART_ON_INIT', false);
+    const DOGU_DEVICE_IOS_IS_IDAPROJECT_VALIDATED = await checkProjectEqual(logger);
     const DOGU_LOG_LEVEL = await getLogLevel(DOGU_RUN_TYPE, appConfigService);
     await killProcessOnPort(DOGU_DEVICE_SERVER_PORT, logger).catch((err) => {
       logger.error('killProcessOnPort', { err });
@@ -55,6 +57,7 @@ export class DeviceServerChild implements Child {
           DOGU_LOG_LEVEL,
           DOGU_DEVICE_PLATFORM_ENABLED,
           DOGU_DEVICE_IOS_RESTART_ON_INIT: DOGU_DEVICE_IOS_RESTART_ON_INIT ? 'true' : 'false',
+          DOGU_DEVICE_IOS_IS_IDAPROJECT_VALIDATED: DOGU_DEVICE_IOS_IS_IDAPROJECT_VALIDATED ? 'true' : 'false',
         },
       },
       childLogger: logger,

--- a/nm-space/projects/dost/src/pages/iOSSettings.tsx
+++ b/nm-space/projects/dost/src/pages/iOSSettings.tsx
@@ -16,7 +16,7 @@ function IosSettings() {
   const [xcodeResult, setXcodeResult] = useState<ExternalValidationResult | null>(null);
   const [isRestartIosOnInit, setIsRestartIosOnInit] = useState(false);
   const { iosStatus, setIosStatus } = useIosSettingsStatus();
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { isOpen: isRestartOpen, onOpen: onRestartOpen, onClose: onRestartClose } = useDisclosure();
 
   const onValidateEnd = useCallback(
     (key: ExternalKey, validateResult: ExternalValidationResult) => {
@@ -30,6 +30,12 @@ function IosSettings() {
         }
         return status;
       });
+      if (key == 'ios-device-agent-build' && validateResult.valid) {
+        const beforeStatus = iosStatus?.find((status) => status.key === key);
+        if (beforeStatus && beforeStatus.isValid === false) {
+          onRestartOpen();
+        }
+      }
       setIosStatus(newStatus);
     },
     [iosStatus],
@@ -57,7 +63,7 @@ function IosSettings() {
     try {
       await ipc.appConfigClient.set<boolean>('DOGU_DEVICE_IOS_RESTART_ON_INIT', checked);
       setIsRestartIosOnInit(checked);
-      onOpen();
+      onRestartOpen();
     } catch (e) {
       ipc.rendererLogger.error('Error while setting DOGU_DEVICE_IOS_RESTART_ON_INIT', { error: e });
     }
@@ -112,7 +118,7 @@ function IosSettings() {
           </BorderBox>
         </List>
       </Center>
-      <RestartAlert isOpen={isOpen} onClose={onClose} />
+      <RestartAlert isOpen={isRestartOpen} onClose={onRestartClose} />
     </div>
   );
 }

--- a/nm-space/projects/dost/src/pages/iOSSettings.tsx
+++ b/nm-space/projects/dost/src/pages/iOSSettings.tsx
@@ -30,7 +30,7 @@ function IosSettings() {
         }
         return status;
       });
-      if (key == 'ios-device-agent-build' && validateResult.valid) {
+      if (key === 'ios-device-agent-build' && validateResult.valid) {
         const beforeStatus = iosStatus?.find((status) => status.key === key);
         if (beforeStatus && beforeStatus.isValid === false) {
           onRestartOpen();

--- a/packages/typescript-private/device-server/src/internal/channel/ios-channel.ts
+++ b/packages/typescript-private/device-server/src/internal/channel/ios-channel.ts
@@ -129,7 +129,7 @@ export class IosChannel implements DeviceChannel {
     }
 
     if (!env.DOGU_DEVICE_IOS_IS_IDAPROJECT_VALIDATED) {
-      throw new Error('iOSDeviceAgent build is not latest. please clean and build iOSDeviceAgent.xcodeproj');
+      throw new Error('iOSDeviceAgent build is not latest. Please clean and build iOSDeviceAgent.xcodeproj');
     }
 
     const logger = createIdaLogger(param.serial);

--- a/packages/typescript-private/device-server/src/internal/channel/ios-channel.ts
+++ b/packages/typescript-private/device-server/src/internal/channel/ios-channel.ts
@@ -109,16 +109,27 @@ export class IosChannel implements DeviceChannel {
       }
     }
 
-    if (!(await WebdriverAgentProcess.isReady(serial))) {
+    const isWdaReady = await WebdriverAgentProcess.isReady(serial);
+    if (isWdaReady === 'build not found') {
+      throw new Error(`WebDriverAgent can't be executed on this device. Please build WebDriverAgent.xcodeproj.`);
+    }
+    if (isWdaReady === 'device not registered') {
       throw new Error(
-        `WebDriverAgent can't be executed on this device. Please register your device. reference: https://developer.apple.com/help/account/register-devices/register-a-single-device. `,
+        `WebDriverAgent can't be executed on this device. Please register your device. reference: https://developer.apple.com/help/account/register-devices/register-a-single-device.`,
+      );
+    }
+    const isIdaReady = await IosDeviceAgentProcess.isReady(serial);
+    if (isIdaReady === 'build not found') {
+      throw new Error(`iOSDeviceAgent can't be executed on this device. Please build iOSDeviceAgent.xcodeproj.`);
+    }
+    if (isIdaReady === 'device not registered') {
+      throw new Error(
+        `iOSDeviceAgent can't be executed on this device. Please register your device. reference: https://developer.apple.com/help/account/register-devices/register-a-single-device.`,
       );
     }
 
-    if (!(await IosDeviceAgentProcess.isReady(serial))) {
-      throw new Error(
-        `iOSDeviceAgent can't be executed on this device. Please register your device. reference: https://developer.apple.com/help/account/register-devices/register-a-single-device. `,
-      );
+    if (!env.DOGU_DEVICE_IOS_IS_IDAPROJECT_VALIDATED) {
+      throw new Error('iOSDeviceAgent build is not latest. please clean and build iOSDeviceAgent.xcodeproj');
     }
 
     const logger = createIdaLogger(param.serial);

--- a/packages/typescript-private/device-server/src/internal/externals/cli/ios-device-agent.ts
+++ b/packages/typescript-private/device-server/src/internal/externals/cli/ios-device-agent.ts
@@ -192,7 +192,7 @@ class ZombieIdaXCTest implements Zombieable {
       ZombieServiceInstance.notifyDie(this);
     });
 
-    for await (const _ of loopTime(Milisecond.t3Seconds, Milisecond.t5Minutes)) {
+    for await (const _ of loopTime(Milisecond.t3Seconds, Milisecond.t3Minutes)) {
       if (await this.isHealth()) {
         break;
       }

--- a/packages/typescript-private/device-server/src/internal/externals/cli/ios-device-agent.ts
+++ b/packages/typescript-private/device-server/src/internal/externals/cli/ios-device-agent.ts
@@ -1,5 +1,5 @@
 import { Platform, Serial } from '@dogu-private/types';
-import { delay, loopTime, Milisecond, Printable, setAxiosErrorFilterToIntercepter, stringifyError } from '@dogu-tech/common';
+import { delay, FilledPrintable, loopTime, Milisecond, Printable, setAxiosErrorFilterToIntercepter, stringifyError } from '@dogu-tech/common';
 import { HostPaths } from '@dogu-tech/node';
 import axios, { AxiosInstance } from 'axios';
 import _ from 'lodash';
@@ -26,7 +26,7 @@ export class IosDeviceAgentProcess {
     private readonly grpcDevicePort: number,
     private readonly webDriverForwardPort: number,
     private readonly webDriverPort: number,
-    private readonly logger: Printable,
+    private readonly logger: FilledPrintable,
   ) {
     ZombieServiceInstance.deleteComponentIfExist((zombieable: Zombieable): boolean => {
       if (zombieable instanceof ZombieIdaXCTest) {
@@ -68,7 +68,7 @@ export class IosDeviceAgentProcess {
     grpcDevicePort: number,
     webDriverForwardPort: number,
     webDriverDevicePort: number,
-    logger: Printable,
+    logger: FilledPrintable,
   ): Promise<IosDeviceAgentProcess> {
     let webDriverPort = webDriverDevicePort;
     let grpcPort = grpcDevicePort;
@@ -137,7 +137,7 @@ class ZombieIdaXCTest implements Zombieable {
     private readonly webDriverPort: number,
     private readonly grpcPort: number,
     // private readonly iosDeviceControllerGrpcClient: IosDeviceControllerGrpcClient,
-    private readonly logger: Printable,
+    private readonly logger: FilledPrintable,
   ) {
     this.zombieWaiter = ZombieServiceInstance.addComponent(this);
     this.wdaClient = axios.create({
@@ -182,11 +182,11 @@ class ZombieIdaXCTest implements Zombieable {
     await this.dissmissAlert(sessionId);
 
     await this.xctestrunfile.updateIdaXctestrunFile(this.webDriverPort, this.grpcPort);
-    await XcodeBuild.killPreviousXcodebuild(this.serial, `ios-device-agent.*${this.serial}`, this.printable).catch(() => {
+    await XcodeBuild.killPreviousXcodebuild(this.serial, `ios-device-agent.*${this.serial}`, this.logger).catch(() => {
       this.logger.warn?.('killPreviousXcodebuild failed');
     });
     await delay(1000);
-    this.xctestrun = XcodeBuild.testWithoutBuilding('ida', xctestrunPath, this.serial, { waitForLog: { str: 'ServerURLHere', timeout: Milisecond.t2Minutes } }, this.printable);
+    this.xctestrun = XcodeBuild.testWithoutBuilding('ida', xctestrunPath, this.serial, { waitForLog: { str: 'ServerURLHere', timeout: Milisecond.t2Minutes } }, this.logger);
     this.xctestrun.proc.on('close', () => {
       this.xctestrun = null;
       ZombieServiceInstance.notifyDie(this);

--- a/packages/typescript-private/device-server/src/internal/externals/cli/ios-device-agent.ts
+++ b/packages/typescript-private/device-server/src/internal/externals/cli/ios-device-agent.ts
@@ -185,6 +185,7 @@ class ZombieIdaXCTest implements Zombieable {
     await XcodeBuild.killPreviousXcodebuild(this.serial, `ios-device-agent.*${this.serial}`, this.printable).catch(() => {
       this.logger.warn?.('killPreviousXcodebuild failed');
     });
+    await delay(1000);
     this.xctestrun = XcodeBuild.testWithoutBuilding('ida', xctestrunPath, this.serial, { waitForLog: { str: 'ServerURLHere', timeout: Milisecond.t2Minutes } }, this.printable);
     this.xctestrun.proc.on('close', () => {
       this.xctestrun = null;

--- a/packages/typescript-private/device-server/src/internal/externals/cli/ios-device-agent.ts
+++ b/packages/typescript-private/device-server/src/internal/externals/cli/ios-device-agent.ts
@@ -52,12 +52,16 @@ export class IosDeviceAgentProcess {
     this.grpcTunnel = new ZombieTunnel(this.serial, this.grpcForwardPort, this.grpcDevicePort, this.logger);
   }
 
-  static async isReady(serial: Serial): Promise<boolean> {
-    const originDerivedData = await DerivedData.create(HostPaths.external.xcodeProject.idaDerivedDataPath());
-    if (!originDerivedData.hasSerial(serial)) {
-      return false;
+  static async isReady(serial: Serial): Promise<'build not found' | 'device not registered' | 'ok'> {
+    try {
+      const originDerivedData = await DerivedData.create(HostPaths.external.xcodeProject.idaDerivedDataPath());
+      if (!originDerivedData.hasSerial(serial)) {
+        return 'device not registered';
+      }
+    } catch (e) {
+      return 'build not found';
     }
-    return true;
+    return 'ok';
   }
 
   static async start(

--- a/packages/typescript-private/device-server/src/internal/externals/cli/ios-device-agent.ts
+++ b/packages/typescript-private/device-server/src/internal/externals/cli/ios-device-agent.ts
@@ -186,13 +186,13 @@ class ZombieIdaXCTest implements Zombieable {
       this.logger.warn?.('killPreviousXcodebuild failed');
     });
     await delay(1000);
-    this.xctestrun = XcodeBuild.testWithoutBuilding('ida', xctestrunPath, this.serial, { waitForLog: { str: 'ServerURLHere', timeout: Milisecond.t2Minutes } }, this.logger);
+    this.xctestrun = XcodeBuild.testWithoutBuilding('ida', xctestrunPath, this.serial, { idleLogTimeoutMillis: Milisecond.t2Minutes }, this.logger);
     this.xctestrun.proc.on('close', () => {
       this.xctestrun = null;
       ZombieServiceInstance.notifyDie(this);
     });
 
-    for await (const _ of loopTime(Milisecond.t3Seconds, Milisecond.t2Minutes)) {
+    for await (const _ of loopTime(Milisecond.t3Seconds, Milisecond.t5Minutes)) {
       if (await this.isHealth()) {
         break;
       }

--- a/packages/typescript-private/device-server/src/internal/externals/cli/ios-device-agent.ts
+++ b/packages/typescript-private/device-server/src/internal/externals/cli/ios-device-agent.ts
@@ -186,7 +186,7 @@ class ZombieIdaXCTest implements Zombieable {
       this.logger.warn?.('killPreviousXcodebuild failed');
     });
     await delay(1000);
-    this.xctestrun = XcodeBuild.testWithoutBuilding('ida', xctestrunPath, this.serial, { idleLogTimeoutMillis: Milisecond.t2Minutes }, this.logger);
+    this.xctestrun = XcodeBuild.testWithoutBuilding('ida', xctestrunPath, this.serial, { idleLogTimeoutMillis: Milisecond.t1Minute + Milisecond.t30Seconds }, this.logger);
     this.xctestrun.proc.on('close', () => {
       this.xctestrun = null;
       ZombieServiceInstance.notifyDie(this);

--- a/packages/typescript-private/device-server/src/internal/externals/cli/webdriver-agent-process.ts
+++ b/packages/typescript-private/device-server/src/internal/externals/cli/webdriver-agent-process.ts
@@ -130,6 +130,7 @@ class ZombieWdaXCTest implements Zombieable {
     await XcodeBuild.killPreviousXcodebuild(this.serial, `webdriveragent.*${this.serial}`, this.printable).catch(() => {
       this.logger.warn?.('killPreviousXcodebuild failed');
     });
+    await delay(1000);
     const originDerivedData = await DerivedData.create(HostPaths.external.xcodeProject.wdaDerivedDataPath());
     if (!originDerivedData.hasSerial(this.serial)) {
       throw new Error(`WebdriverAgent can't be executed on ${this.serial}`);

--- a/packages/typescript-private/device-server/src/internal/externals/cli/webdriver-agent-process.ts
+++ b/packages/typescript-private/device-server/src/internal/externals/cli/webdriver-agent-process.ts
@@ -140,13 +140,13 @@ class ZombieWdaXCTest implements Zombieable {
     if (!xctestrun) {
       throw new Error('xctestrun not found');
     }
-    this.xctestrun = XcodeBuild.testWithoutBuilding('wda', xctestrun.filePath, this.serial, { waitForLog: { str: 'ServerURLHere', timeout: Milisecond.t2Minutes } }, this.logger);
+    this.xctestrun = XcodeBuild.testWithoutBuilding('wda', xctestrun.filePath, this.serial, { idleLogTimeoutMillis: Milisecond.t2Minutes }, this.logger);
     this.xctestrun.proc.on('close', () => {
       this.xctestrun = null;
       ZombieServiceInstance.notifyDie(this);
     });
 
-    for await (const _ of loopTime(Milisecond.t3Seconds, Milisecond.t2Minutes)) {
+    for await (const _ of loopTime(Milisecond.t3Seconds, Milisecond.t5Minutes)) {
       if (await this.isHealth()) {
         break;
       }

--- a/packages/typescript-private/device-server/src/internal/externals/cli/webdriver-agent-process.ts
+++ b/packages/typescript-private/device-server/src/internal/externals/cli/webdriver-agent-process.ts
@@ -43,12 +43,17 @@ export class WebdriverAgentProcess {
     return ret;
   }
 
-  static async isReady(serial: Serial): Promise<boolean> {
-    const originDerivedData = await DerivedData.create(HostPaths.external.xcodeProject.wdaDerivedDataPath());
-    if (!originDerivedData.hasSerial(serial)) {
-      return false;
+  static async isReady(serial: Serial): Promise<'build not found' | 'device not registered' | 'ok'> {
+    try {
+      const originDerivedData = await DerivedData.create(HostPaths.external.xcodeProject.wdaDerivedDataPath());
+      if (!originDerivedData.hasSerial(serial)) {
+        return 'device not registered';
+      }
+    } catch (e) {
+      return 'build not found';
     }
-    return true;
+
+    return 'ok';
   }
 
   delete(): void {

--- a/packages/typescript-private/device-server/src/internal/externals/cli/webdriver-agent-process.ts
+++ b/packages/typescript-private/device-server/src/internal/externals/cli/webdriver-agent-process.ts
@@ -140,7 +140,7 @@ class ZombieWdaXCTest implements Zombieable {
     if (!xctestrun) {
       throw new Error('xctestrun not found');
     }
-    this.xctestrun = XcodeBuild.testWithoutBuilding('wda', xctestrun.filePath, this.serial, { idleLogTimeoutMillis: Milisecond.t2Minutes }, this.logger);
+    this.xctestrun = XcodeBuild.testWithoutBuilding('wda', xctestrun.filePath, this.serial, { idleLogTimeoutMillis: Milisecond.t1Minute + Milisecond.t30Seconds }, this.logger);
     this.xctestrun.proc.on('close', () => {
       this.xctestrun = null;
       ZombieServiceInstance.notifyDie(this);

--- a/packages/typescript-private/device-server/src/internal/externals/cli/webdriver-agent-process.ts
+++ b/packages/typescript-private/device-server/src/internal/externals/cli/webdriver-agent-process.ts
@@ -146,7 +146,7 @@ class ZombieWdaXCTest implements Zombieable {
       ZombieServiceInstance.notifyDie(this);
     });
 
-    for await (const _ of loopTime(Milisecond.t3Seconds, Milisecond.t5Minutes)) {
+    for await (const _ of loopTime(Milisecond.t3Seconds, Milisecond.t3Minutes)) {
       if (await this.isHealth()) {
         break;
       }

--- a/packages/typescript-private/dost-children/src/envs/device-server.ts
+++ b/packages/typescript-private/dost-children/src/envs/device-server.ts
@@ -35,4 +35,8 @@ export class DeviceServerEnv extends PreloadDeviceServerEnv {
   @IsBoolean()
   @TransformBooleanString()
   DOGU_DEVICE_IOS_RESTART_ON_INIT = false;
+
+  @IsBoolean()
+  @TransformBooleanString()
+  DOGU_DEVICE_IOS_IS_IDAPROJECT_VALIDATED = false;
 }

--- a/packages/typescript/common/src/logs.ts
+++ b/packages/typescript/common/src/logs.ts
@@ -51,6 +51,7 @@ export function logLevelTypeToEnum(level: LogLevel): LogLevelEnum {
 
 export interface LogInfo {
   message: unknown;
+  time: number;
   details?: Record<string, unknown>;
 }
 
@@ -203,7 +204,7 @@ export class BufferLogger implements FilledPrintable {
     if (!buffer) {
       return;
     }
-    buffer.push({ message, details });
+    buffer.push({ message, time: Date.now(), details });
     if (this.options.limit > 0 && buffer.length > this.options.limit) {
       buffer.shift();
     }
@@ -301,6 +302,34 @@ export class LoggerHolder implements FilledPrintable {
 
   setLogger(printable: Printable): void {
     this.printable = printable;
+  }
+}
+
+export class IdleCheckLogger implements FilledPrintable {
+  constructor(private _lastLogTime: number = Date.now()) {}
+
+  isBefore(deltaTimeMillis: number): boolean {
+    return Date.now() - this._lastLogTime > deltaTimeMillis;
+  }
+
+  error(message: unknown, details?: Record<string, unknown>): void {
+    this._lastLogTime = Date.now();
+  }
+
+  warn(message: unknown, details?: Record<string, unknown>): void {
+    this._lastLogTime = Date.now();
+  }
+
+  info(message: unknown, details?: Record<string, unknown>): void {
+    this._lastLogTime = Date.now();
+  }
+
+  debug(message: unknown, details?: Record<string, unknown>): void {
+    this._lastLogTime = Date.now();
+  }
+
+  verbose(message: unknown, details?: Record<string, unknown>): void {
+    this._lastLogTime = Date.now();
   }
 }
 

--- a/packages/typescript/common/src/logs.ts
+++ b/packages/typescript/common/src/logs.ts
@@ -174,28 +174,39 @@ export class ConsoleLogger implements FilledPrintable {
 export class BufferLogger implements FilledPrintable {
   readonly buffers = new Map<LogLevel, LogInfo[]>();
 
-  constructor() {
+  constructor(private readonly options: { limit: number } = { limit: 0 }) {
     LogLevel.forEach((level) => this.buffers.set(level, []));
   }
 
   error(message: unknown, details?: Record<string, unknown>): void {
-    this.buffers.get('error')?.push({ message, details });
+    this.pushToBuffer('error', message, details);
   }
 
   warn(message: unknown, details?: Record<string, unknown>): void {
-    this.buffers.get('warn')?.push({ message, details });
+    this.pushToBuffer('warn', message, details);
   }
 
   info(message: unknown, details?: Record<string, unknown>): void {
-    this.buffers.get('info')?.push({ message, details });
+    this.pushToBuffer('info', message, details);
   }
 
   debug(message: unknown, details?: Record<string, unknown>): void {
-    this.buffers.get('debug')?.push({ message, details });
+    this.pushToBuffer('debug', message, details);
   }
 
   verbose(message: unknown, details?: Record<string, unknown>): void {
-    this.buffers.get('verbose')?.push({ message, details });
+    this.pushToBuffer('verbose', message, details);
+  }
+
+  private pushToBuffer(level: LogLevel, message: unknown, details?: Record<string, unknown>): void {
+    const buffer = this.buffers.get(level);
+    if (!buffer) {
+      return;
+    }
+    buffer.push({ message, details });
+    if (this.options.limit > 0 && buffer.length > this.options.limit) {
+      buffer.shift();
+    }
   }
 }
 
@@ -290,5 +301,39 @@ export class LoggerHolder implements FilledPrintable {
 
   setLogger(printable: Printable): void {
     this.printable = printable;
+  }
+}
+
+export class MixedLogger implements FilledPrintable {
+  constructor(readonly loggers: Printable[]) {}
+
+  error(message: unknown, details?: Record<string, unknown>): void {
+    for (const logger of this.loggers) {
+      logger.error(message, details);
+    }
+  }
+
+  warn(message: unknown, details?: Record<string, unknown>): void {
+    for (const logger of this.loggers) {
+      logger.warn?.(message, details);
+    }
+  }
+
+  info(message: unknown, details?: Record<string, unknown>): void {
+    for (const logger of this.loggers) {
+      logger.info(message, details);
+    }
+  }
+
+  debug(message: unknown, details?: Record<string, unknown>): void {
+    for (const logger of this.loggers) {
+      logger.debug?.(message, details);
+    }
+  }
+
+  verbose(message: unknown, details?: Record<string, unknown>): void {
+    for (const logger of this.loggers) {
+      logger.verbose?.(message, details);
+    }
   }
 }

--- a/projects/go-device-controller/internal/pkg/device/surface/aos_surface.go
+++ b/projects/go-device-controller/internal/pkg/device/surface/aos_surface.go
@@ -40,6 +40,10 @@ func (s *aosSurface) Receive() ([]byte, error) {
 		return nil, errors.Errorf("aosSurface.Receive reader is null")
 	}
 	_, buf, err := s.conn.ReadMessage()
+	if err != nil {
+		s.conn = nil
+	}
+
 	return buf, err
 }
 
@@ -48,10 +52,10 @@ func (s *aosSurface) NotifyData(listener SurfaceListener, timeStamp uint32, data
 }
 
 func (s *aosSurface) Close() {
-	if nil != s.conn {
-		if closeEr := s.conn.Close(); closeEr != nil {
-			log.Inst.Error("aosSurface.Close", zap.Error(closeEr))
-		}
+	if nil == s.conn {
+		return
 	}
-	s.conn = nil
+	if closeEr := s.conn.Close(); closeEr != nil {
+		log.Inst.Error("aosSurface.Close", zap.Error(closeEr))
+	}
 }

--- a/projects/ios-device-agent/IOSDeviceAgent/IOSDeviceAgentLib/IOSDeviceAgent.swift
+++ b/projects/ios-device-agent/IOSDeviceAgent/IOSDeviceAgentLib/IOSDeviceAgent.swift
@@ -53,6 +53,7 @@ public final class IOSDeviceAgent {
   private func runInternal() {
     let port = self.config.grpcPort
     let nwport: NWEndpoint.Port = NWEndpoint.Port(rawValue: UInt16(self.config.grpcPort)) ?? 50002
+    yellAlivePeriodically()
     do {
       listener = try NWListener(using: .tcp, on: nwport)
       listener?.stateUpdateHandler = { [weak self] state in
@@ -81,5 +82,12 @@ public final class IOSDeviceAgent {
     } catch {
       Log.shared.error("ScreenServer Failed to start server, error: \(error.localizedDescription)")
     }
+  }
+
+  private func yellAlivePeriodically() {
+    let timer = Timer(timeInterval: 30, repeats: true) { [weak self] _ in
+      Log.shared.info("IOSDeviceAgent is alive")
+    }
+    RunLoop.main.add(timer, forMode: .common)
   }
 }


### PR DESCRIPTION
# PR Template

## Checklist

- [ ] E2E finished.
- [x] Local, Self Hosted and Development environment test finished.
- [x] Local, E2E, Self Hosted, Development and Production env variable checked.
- [ ] (Backend only) DB migration file creation checked.
- [ ] **If this is a API deleted or changed**: Check side effects for API deletion or related code change.

## Related issue
- https://github.com/dogu-team/dogu/issues/415

## Dogu-Agent
- Show Restart popup when ios-device-agent build is validated

## device-server
- DOGU_DEVICE_IOS_IS_IDAPROJECT_LATESET env to skip ios-channel open. if ios-device-agent is old version
- Delete waitForLog when IosDeviceAgent, WebdriverAgent run. replaced with idleLogTimeout
   - Initialization was almost complete, but there were cases where reconnection was attempted again.

## go-device-controller
- Set connection nil only if receive failed.