### PR TITLE
fix: add -allowProvisioningUpdates when wda, ida build

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -11769,6 +11769,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["logform", "npm:2.5.1"],\
             ["nodemon", "npm:2.0.22"],\
             ["octokit", "npm:2.0.7"],\
+            ["pbxproj-dom", "npm:1.2.0"],\
             ["pidtree", "npm:0.6.0"],\
             ["plist", "npm:3.0.6"],\
             ["reflect-metadata", "npm:0.1.13"],\

--- a/nm-space/yarn.lock
+++ b/nm-space/yarn.lock
@@ -4757,6 +4757,7 @@ __metadata:
     logform: 2.5.1
     nodemon: 2.0.22
     octokit: 2.0.7
+    pbxproj-dom: 1.2.0
     pidtree: 0.6.0
     plist: 3.0.6
     reflect-metadata: 0.1.13

--- a/packages/typescript/node/package.json
+++ b/packages/typescript/node/package.json
@@ -34,6 +34,7 @@
     "lodash": "4.17.21",
     "logform": "2.5.1",
     "octokit": "2.0.7",
+    "pbxproj-dom": "1.2.0",
     "pidtree": "0.6.0",
     "plist": "3.0.6",
     "reflect-metadata": "0.1.13",

--- a/packages/typescript/node/src/index.ts
+++ b/packages/typescript/node/src/index.ts
@@ -17,6 +17,7 @@ export * from './git';
 export * from './github/octokit-context';
 export * from './host-paths';
 export * from './ios/mobile-provisioning-profile';
+export * from './ios/pbxproj';
 export * from './ios/plist-parser';
 export * from './logs';
 export * from './macos-utils';

--- a/packages/typescript/node/src/ios/pbxproj.ts
+++ b/packages/typescript/node/src/ios/pbxproj.ts
@@ -1,0 +1,24 @@
+import { Xcode } from 'pbxproj-dom/xcode';
+
+export class Pbxproj {
+  private readonly xcode: Xcode;
+  constructor(private readonly filePath: string) {
+    this.xcode = Xcode.open(filePath);
+  }
+
+  getSingingStyle(targetName: string): 'Automatic' | 'Manual' | 'None' {
+    const config = this.xcode.document.targets.find((target) => target.name === targetName)?.buildConfigurationsList.buildConfigurations[0];
+    if (!config) {
+      return 'None';
+    }
+    var buildSettings = config.ast.get('buildSettings');
+    var type = buildSettings.get('CODE_SIGN_STYLE').text;
+    if (type === 'Automatic') {
+      return 'Automatic';
+    }
+    if (type === 'Manual') {
+      return 'Manual';
+    }
+    return 'None';
+  }
+}

--- a/packages/typescript/node/src/ios/pbxproj.ts
+++ b/packages/typescript/node/src/ios/pbxproj.ts
@@ -7,18 +7,21 @@ export class Pbxproj {
   }
 
   getSingingStyle(targetName: string): 'Automatic' | 'Manual' | 'None' {
-    const config = this.xcode.document.targets.find((target) => target.name === targetName)?.buildConfigurationsList.buildConfigurations[0];
-    if (!config) {
+    const configs = this.xcode.document.targets.find((target) => target.name === targetName)?.buildConfigurationsList.buildConfigurations;
+    if (!configs) {
       return 'None';
     }
-    var buildSettings = config.ast.get('buildSettings');
-    var type = buildSettings.get('CODE_SIGN_STYLE').text;
-    if (type === 'Automatic') {
-      return 'Automatic';
+    for (const config of configs) {
+      const buildSettings = config.ast.get('buildSettings');
+      const type = buildSettings.get('CODE_SIGN_STYLE').text;
+      if (type === 'Automatic') {
+        return 'Automatic';
+      }
+      if (type === 'Manual') {
+        return 'Manual';
+      }
     }
-    if (type === 'Manual') {
-      return 'Manual';
-    }
+
     return 'None';
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5505,6 +5505,7 @@ __metadata:
     logform: 2.5.1
     nodemon: 2.0.22
     octokit: 2.0.7
+    pbxproj-dom: 1.2.0
     pidtree: 0.6.0
     plist: 3.0.6
     reflect-metadata: 0.1.13


### PR DESCRIPTION
# PR Template

## Checklist

- [ ] E2E finished.
- [x] Local, Self Hosted and Development environment test finished.
- [x] Local, E2E, Self Hosted, Development and Production env variable checked.
- [ ] (Backend only) DB migration file creation checked.
- [ ] **If this is a API deleted or changed**: Check side effects for API deletion or related code change.

## Related issues
- WebDriverAgent, iOSDeviceAgent build fail with message 
```
No profiles for 'com.xxx.xxx' were found: Xcode couldn't find any iOS App Development provisioning profiles
matching 'com.xxx.xxx'. Automatic signing is disabled and unable to generate a profile. To enable automatic signing, pass
-allowProvisioningUpdates to xcodebuild.
```
even if WebDriverAgent, iOSDeviceAgent build succeed in xcode